### PR TITLE
Fix crash when connecting links

### DIFF
--- a/js/QuickConnection.js
+++ b/js/QuickConnection.js
@@ -198,9 +198,6 @@ export class QuickConnection {
 			return;
 		}
 
-		ctx.save();
-		this.canvas.ds.toCanvasContext(ctx);
-
 		this.insideConnection = null;
 
 		const connectionInfo = this.getCurrentConnection();
@@ -209,6 +206,13 @@ export class QuickConnection {
 			const {
 				node, input, output, slot,
 			} = connectionInfo;
+			if (!input && !output) {
+				return;
+			}
+
+			ctx.save();
+			this.canvas.ds.toCanvasContext(ctx);
+
 			const slotPos = new Float32Array(2);
 
 			const isInput = input ? true : false;

--- a/js/QuickConnection.js
+++ b/js/QuickConnection.js
@@ -440,7 +440,7 @@ export class QuickConnection {
 
 				ctx.font = oldFont;
 			}
-		}
 		ctx.restore();
+		}
 	}
 }


### PR DESCRIPTION
Prior to ComfyUI_frontend 1.4.3, there was an edge case where both connecting links `input` and `output` could be null.

As of 1.4.3, this is always the case when a user clicks a slot or reroute, but does not drag it anywhere.  The expected UX is "cancel, no changes made".

Hope this helps.